### PR TITLE
Added ability to create workspace for Esign

### DIFF
--- a/src/features/Api/externalIntegrationsApi.js
+++ b/src/features/Api/externalIntegrationsApi.js
@@ -1,5 +1,3 @@
-import { data } from "react-router-dom";
-
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const externalIntegrationsApi = createApi({

--- a/src/features/Rent/components/EsignConnect/EsignConnect.jsx
+++ b/src/features/Rent/components/EsignConnect/EsignConnect.jsx
@@ -5,25 +5,11 @@ import { v4 as uuidv4 } from "uuid";
 import dayjs from "dayjs";
 
 import {
-  AddLinkRounded,
-  CloudCircleRounded,
-  EjectRounded,
   HelpOutlineRounded,
   SecurityRounded,
   SupportAgentRounded,
 } from "@mui/icons-material";
-import {
-  Alert,
-  Box,
-  Card,
-  Grid2,
-  Skeleton,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import AButton from "common/AButton";
-import AIconButton from "common/AIconButton";
+import { Card, Grid2, Skeleton } from "@mui/material";
 import RowHeader from "common/RowHeader/RowHeader";
 import { useCreateWorkspaceMutation } from "features/Api/externalIntegrationsApi";
 import {
@@ -31,6 +17,7 @@ import {
   useUpdateUserByUidMutation,
 } from "features/Api/firebaseUserApi";
 import RecentDocuments from "features/Rent/components/EsignConnect/RecentDocuments";
+import StatusCard from "features/Rent/components/EsignConnect/StatusCard";
 import HelpAndSupport from "features/Rent/components/ExternalIntegrations/HelpAndSupport";
 import { fetchLoggedInUser } from "features/Rent/utils";
 
@@ -123,89 +110,13 @@ export default function EsignConnect() {
   return (
     <Grid2 container spacing={2}>
       <Grid2 size={12}>
-        {/* Esign Status Card goes here*/}
-        <Card elevation={0} sx={{ p: 1 }}>
-          <Box sx={{ display: "flex", alignItems: "center" }}>
-            <RowHeader
-              title="Account Connection"
-              caption="View details about your esign account."
-              sxProps={{ textAlign: "left" }}
-            />
-            <Box
-              sx={{
-                ml: "auto",
-                display: "flex",
-                alignItems: "center",
-                gap: 1,
-              }}
-            >
-              <Tooltip
-                title={isEsignConnected ? "Disconnect esign" : "Link esign"}
-              >
-                <AIconButton
-                  size="small"
-                  disabled
-                  label={
-                    isEsignConnected ? (
-                      <EjectRounded color="error" fontSize="small" />
-                    ) : (
-                      <AddLinkRounded color="error" fontSize="small" />
-                    )
-                  }
-                  onClick={isEsignConnected ? disconnectEsign : connectEsign}
-                />
-              </Tooltip>
-            </Box>
-          </Box>
-          <Alert severity={!isEsignConnected ? "info" : "success"}>
-            Link with our provider esign account for easy access for signed
-            documents.
-          </Alert>
-
-          {!isEsignConnected ? (
-            <AButton
-              sx={{ mt: 2 }}
-              startIcon={<CloudCircleRounded fontSize="small" />}
-              label="Link Esign"
-              variant="contained"
-              onClick={connectEsign}
-              loading={isUpdateUserLoading}
-            />
-          ) : (
-            <>
-              <Typography variant="body2" color="text.secondary" gutterBottom>
-                Your docusign account is connected. Verify docusign details.
-              </Typography>
-              <Stack direction="row" spacing={2}>
-                <Stack>
-                  <Typography
-                    variant="body2"
-                    color="textPrimary"
-                    fontWeight="bold"
-                  >
-                    Docusign ID:
-                  </Typography>
-                  <Typography variant="body2" color="error">
-                    {userData?.esignAccountId}
-                  </Typography>
-                </Stack>
-
-                <Stack>
-                  <Typography
-                    variant="body2"
-                    color="textPrimary"
-                    fontWeight="bold"
-                  >
-                    Status
-                  </Typography>
-                  <Typography variant="body2" color="info">
-                    {userData?.esignAccountType}
-                  </Typography>
-                </Stack>
-              </Stack>
-            </>
-          )}
-        </Card>
+        <StatusCard
+          connectEsign={connectEsign}
+          isUpdateUserLoading={isUpdateUserLoading}
+          handleClick={isEsignConnected ? disconnectEsign : connectEsign}
+          isEsignConnected={isEsignConnected}
+          esignAccountWorkspaceId={userData?.esignAccountWorkspaceId}
+        />
       </Grid2>
 
       <Grid2 size={12}>

--- a/src/features/Rent/components/EsignConnect/StatusCard.jsx
+++ b/src/features/Rent/components/EsignConnect/StatusCard.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+
+import {
+  AddLinkRounded,
+  CloudCircleRounded,
+  RemoveCircleOutlineRounded,
+} from "@mui/icons-material";
+import { Alert, Box, Card, Stack, Tooltip, Typography } from "@mui/material";
+import AButton from "common/AButton";
+import AIconButton from "common/AIconButton";
+import RowHeader from "common/RowHeader/RowHeader";
+
+export default function StatusCard({
+  isEsignConnected,
+  handleClick,
+  connectEsign,
+  isUpdateUserLoading,
+  esignAccountWorkspaceId,
+}) {
+  return (
+    <Card elevation={0} sx={{ p: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center" }}>
+        <RowHeader
+          title="Account Connection"
+          caption="View details about your esign account."
+          sxProps={{ textAlign: "left" }}
+        />
+        <Box
+          sx={{
+            ml: "auto",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
+          <Tooltip title={isEsignConnected ? "Disconnect esign" : "Link esign"}>
+            <AIconButton
+              size="small"
+              label={
+                isEsignConnected ? (
+                  <RemoveCircleOutlineRounded color="error" fontSize="small" />
+                ) : (
+                  <AddLinkRounded color="error" fontSize="small" />
+                )
+              }
+              onClick={handleClick}
+            />
+          </Tooltip>
+        </Box>
+      </Box>
+      <Alert severity={!isEsignConnected ? "info" : "success"}>
+        Link with our provider esign account for easy access for signed
+        documents.
+      </Alert>
+
+      {!isEsignConnected ? (
+        <AButton
+          sx={{ mt: 2 }}
+          startIcon={<CloudCircleRounded fontSize="small" />}
+          label="Link Esign"
+          variant="contained"
+          onClick={connectEsign}
+          loading={isUpdateUserLoading}
+        />
+      ) : (
+        <>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            Your Esign account is connected. Verify E-sign details.
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            <Stack>
+              <Typography variant="body2" color="textPrimary" fontWeight="bold">
+                Esign Workspace ID:
+              </Typography>
+              <Typography variant="body2" color="error">
+                {esignAccountWorkspaceId}
+              </Typography>
+            </Stack>
+
+            <Stack>
+              <Typography variant="body2" color="textPrimary" fontWeight="bold">
+                Status
+              </Typography>
+              <Typography variant="body2" color="info">
+                Online
+              </Typography>
+            </Stack>
+          </Stack>
+        </>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
The purpose of this PR is to create workspace for users under Esign.

**Technical Information**

1. An account can be linked to E-sign via the button `Link E-sign`.
2. When an account is created successfully, a workspace is created for the selected user.
3. Identification of this workspace is via UUID generated on the client webapp.
4. Users are allowed to disconnect via `Disconnect` IconButton on the same component.
5. When the users attempts to `rejoin` or `link e-sign` again, a new UUID is generated on the webapp.
6. This UUID is funneled to backend system for workspace creation purposes. 

## Testing Steps
1. Link an account to E-sign.
2. View details of workspace once the creation is complete.
3. Notice skeletons for loading as well.
4. Disconnect should unlink the Esign workspace and display as such in the webapp. 
5. Create new E-sign workspace. A new UUID should be displayed.

## Screenshots / Visuals
<img width="1294" height="991" alt="image" src="https://github.com/user-attachments/assets/f31dba72-8f65-4c9d-b973-4b3e55d82493" />
