### PR TITLE
Added support to display visual elements in Raspy AI

### DIFF
--- a/src/features/Raspy/ResponseDetails.jsx
+++ b/src/features/Raspy/ResponseDetails.jsx
@@ -14,6 +14,8 @@ import {
 } from "@mui/material";
 import EmptyComponent from "common/EmptyComponent";
 import { pluralize } from "common/utils";
+import RaspyAIPieChart from "features/Raspy/VisualElements/RaspyAIPieChart";
+import RaspyAISeriesChart from "features/Raspy/VisualElements/RaspyAISeriesChart";
 
 const RecommendedActionList = ({ data = [] }) => {
   if (data?.length <= 0) {
@@ -125,6 +127,12 @@ export default function ResponseDetails({ data = {} }) {
 
   const portfolioHealth = data?.portfolioHealth || {};
   const financialHealth = data?.financialHealth || {};
+  const projectedRentalChangeData = data?.projectedRentalChange || [];
+  const projectedYearlyRentData = data?.projectedYearlyRent || [];
+
+  const isProjectedDatasetEmpty =
+    projectedRentalChangeData.length <= 0 ||
+    projectedYearlyRentData.length <= 0;
   return (
     <Stack spacing={1}>
       {/* Recommended Action Alert Blocks */}
@@ -170,6 +178,27 @@ export default function ResponseDetails({ data = {} }) {
           data={financialHealth?.securityDepositsCollected || 0}
           label="Collected Security Deposits"
         />
+      </Stack>
+      <Stack
+        spacing={1}
+        justifyContent="space-between"
+        direction={{ sm: "row", xs: "column" }}
+        alignSelf={isProjectedDatasetEmpty ? "center" : "inherit"}
+      >
+        {isProjectedDatasetEmpty ? (
+          <EmptyComponent caption="No recommendations to display" />
+        ) : (
+          <>
+            <RaspyAISeriesChart
+              label="Rental Income Projection"
+              data={projectedRentalChangeData}
+            />
+            <RaspyAIPieChart
+              label="Collected Rents"
+              data={projectedYearlyRentData}
+            />
+          </>
+        )}
       </Stack>
       {/* Recommended Actions List View */}
       <Stack>

--- a/src/features/Raspy/VisualElements/RaspyAIPieChart.jsx
+++ b/src/features/Raspy/VisualElements/RaspyAIPieChart.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+
+import { PolarArea } from "react-chartjs-2";
+
+import { Box } from "@mui/material";
+import {
+  ArcElement,
+  Chart as ChartJS,
+  Legend,
+  RadialLinearScale,
+  Title,
+  Tooltip,
+} from "chart.js";
+import EmptyComponent from "common/EmptyComponent";
+
+ChartJS.register(RadialLinearScale, ArcElement, Tooltip, Legend, Title);
+
+const RaspyAIPieChart = ({ label, data = [] }) => {
+  const [chartData, setChartData] = useState(null);
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      title: {
+        display: true,
+        text: label,
+      },
+      legend: {
+        display: false,
+      },
+      scales: {
+        r: {
+          ticks: {
+            display: false, // hides the numbers
+          },
+          grid: {
+            display: false, // optional: remove circular grid lines
+          },
+        },
+      },
+    },
+  };
+
+  useEffect(() => {
+    const [labels, values, backgroundColors] = data;
+    setChartData({
+      labels,
+      datasets: [
+        {
+          label: "Collected Rent",
+          data: values,
+          backgroundColor: backgroundColors,
+        },
+      ],
+    });
+  }, [data]);
+
+  return (
+    <Box
+      sx={{
+        height: "15rem",
+        width: "50%",
+      }}
+    >
+      {!chartData ? (
+        <EmptyComponent caption="Sorry, no matching records found." />
+      ) : (
+        <PolarArea data={chartData} options={options} />
+      )}
+    </Box>
+  );
+};
+
+export default RaspyAIPieChart;

--- a/src/features/Raspy/VisualElements/RaspyAISeriesChart.jsx
+++ b/src/features/Raspy/VisualElements/RaspyAISeriesChart.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+
+import { Line } from "react-chartjs-2";
+
+import { Box } from "@mui/material";
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Title,
+  Tooltip,
+} from "chart.js";
+import EmptyComponent from "common/EmptyComponent";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Title,
+  Legend,
+);
+
+const RaspyAISeriesChart = ({ label, data = [] }) => {
+  const [chartData, setChartData] = useState(null);
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      title: {
+        display: true,
+        text: label,
+      },
+      legend: {
+        display: true,
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: false,
+        ticks: {
+          precision: 0,
+        },
+      },
+    },
+  };
+
+  useEffect(() => {
+    const [labels = [], historicalValues = [], forecast = []] = data;
+    setChartData({
+      labels,
+      datasets: [
+        {
+          label: "Rent history",
+          data: historicalValues,
+          borderWidth: 2,
+          tension: 0.4,
+          backgroundColor: "rgba(153, 102, 255, 0.7)",
+          borderColor: "rgba(153, 102, 255, 1)",
+        },
+        {
+          label: "Rent Forecast",
+          data: [...Array(historicalValues.length).fill(null), ...forecast],
+          borderWidth: 2,
+          tension: 0.4,
+          backgroundColor: "rgba(255, 99, 132, 0.7)",
+          borderColor: "rgba(255, 99, 132, 0.7)",
+        },
+      ],
+    });
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        height: "15rem",
+        width: "50%",
+      }}
+    >
+      {!chartData ? (
+        <EmptyComponent caption="Sorry, no matching records found." />
+      ) : (
+        <Line data={chartData} options={options} />
+      )}
+    </Box>
+  );
+};
+
+export default RaspyAISeriesChart;

--- a/src/features/Rent/components/AssociateTenantPopup/AssociateTenantPopup.jsx
+++ b/src/features/Rent/components/AssociateTenantPopup/AssociateTenantPopup.jsx
@@ -796,7 +796,10 @@ export default function AssociateTenantPopup({
           variant="outlined"
           type="submit"
           disabled={
-            !isValid || (!isSoR && !isPrimaryTenant) || showLateFeeAlert
+            !isValid ||
+            Object.keys(errors).length > 0 ||
+            (!isSoR && !isPrimaryTenant) ||
+            showLateFeeAlert
           }
         />
 

--- a/src/features/Rent/components/AssociateTenantPopup/TenantEmailAutocomplete.jsx
+++ b/src/features/Rent/components/AssociateTenantPopup/TenantEmailAutocomplete.jsx
@@ -113,7 +113,8 @@ export default function TenantEmailAutocomplete({
             renderInput={(params) => (
               <TextField
                 {...params}
-                variant="standard"
+                size="small"
+                variant="outlined"
                 label="Tenant Email Address *"
                 placeholder="Select or enter tenant email address"
                 error={!!errors.email}

--- a/src/features/Rent/components/Properties/ViewPropertyAccordionDetails.jsx
+++ b/src/features/Rent/components/Properties/ViewPropertyAccordionDetails.jsx
@@ -52,7 +52,7 @@ import {
 // DefaultOneTimePaymentValues ...
 // defines the default values for one time payment form
 const DefaultOneTimePaymentValues = {
-  amount: 0,
+  amount: "",
   note: "",
 };
 
@@ -299,9 +299,10 @@ const ViewPropertyAccordionDetails = ({
               >
                 {primaryTenant?.email}
               </Typography>
-              <Tooltip title="Send Email">
+              <Tooltip title="Create personalized email">
                 <IconButton
                   size="small"
+                  component="a"
                   href={`mailto:${primaryTenant?.email}`}
                   target="_blank"
                 >


### PR DESCRIPTION
The purpose of this PR is to support visual elements in Raspy AI. The goal is to support the AI chatbot to produce chart data so that we can display it to the user. We have created some test data that can display similar stuffs and we will update down the line.

# Visuals / Screenshots
<img width="926" height="1059" alt="image" src="https://github.com/user-attachments/assets/e2692ca1-597f-4e2a-a97d-f96b7b969a84" />
