### PR TITLE
Added support to protect rental payments

### DIFF
--- a/src/features/Rent/common/PropertyOwnerInfoCard.jsx
+++ b/src/features/Rent/common/PropertyOwnerInfoCard.jsx
@@ -83,6 +83,9 @@ export default function PropertyOwnerInfoCard({
 
   const tenant = data.find((item) => item);
   const currentMonthRentData = getRentByMonthResult?.data;
+
+  // used to confirm if payee understands that bank transactions sometimes takes > 3 days to complete.
+  const hasRecentPaymentAttemptBeenMade = currentMonthRentData?.length > 0;
   const paymentCompleteForCurrentMonth = Boolean(
     currentMonthRentData?.some(
       (item) =>
@@ -323,10 +326,18 @@ export default function PropertyOwnerInfoCard({
                   </Alert>
                 </Box>
 
+                {hasRecentPaymentAttemptBeenMade ? (
+                  <Alert variant="filled" severity="error">
+                    A rent payment was recently attempted. Some bank accounts
+                    may take upto 2-3 days for processing. Are you sure you want
+                    to proceed?
+                  </Alert>
+                ) : null}
+
                 <AButton
                   size="small"
                   variant="contained"
-                  label="Pay rent"
+                  label="Pay Rent"
                   sx={{ margin: "0.4rem 0rem" }}
                   loading={isStripeStatusLoading}
                   disabled={!stripeValid || paymentCompleteForCurrentMonth}

--- a/src/features/Rent/components/Faq/Faq.jsx
+++ b/src/features/Rent/components/Faq/Faq.jsx
@@ -21,7 +21,7 @@ const faqItems = [
   {
     icon: <SaveAltRounded fontSize="small" />,
     q: "Can I update property data even after tenants are added to the property?",
-    ans: "Yes, you can update property data after tenants are added to the property, however once e-sign is completed, editing is prohibited until tenants are removed from the property. Performing actions such as removing a tenant from a property, adding rent payments to the property and / or editing the property will alert the tenant and property owner VIA email.",
+    ans: "No, you cannot update property data after tenants are added to the property. You may edit the property details once the tenants are removed from the property. Performing actions such as removing a tenant from a property, adding rent payments to the property and / or editing the property will alert the tenant and property owner VIA email, while keeping all audit trails in effect.",
   },
   {
     icon: <AddCircleOutlineRounded fontSize="small" />,
@@ -41,7 +41,7 @@ const faqItems = [
   {
     icon: <EmailRounded fontSize="small" />,
     q: "Do you send reminders if the rent is due?",
-    ans: "Yes, we do send automatic email reminders. Emails are sent out periodically and can also be manually triggered.",
+    ans: "Yes, our servers are configured to send periodic reminders for rental payments. Tenants are expected to recieve email notifications every 7th, 3rd, 2nd, 1st and the day of. If the due date is passed, tenants can be expected to recieve email notifications every day until the payment is complete or until the month has passed. In the case of the latter, the system automatically repurposes itself with period emails. If you would like to send reminders on your own accord, you also may do such free of charge from the Quick Actions menu.",
   },
   {
     icon: <PrintOutlined fontSize="small" />,

--- a/src/features/Rent/components/Widgets/QuickActions.jsx
+++ b/src/features/Rent/components/Widgets/QuickActions.jsx
@@ -272,10 +272,9 @@ export default function QuickActions({ property }) {
                     }}
                   />
                   {hasRecentPaymentAttemptBeenMade ? (
-                    <Alert variant="outlined" severity="warning">
+                    <Alert variant="filled" severity="error">
                       A rent payment was recently attempted. Businesses may take
-                      upto 2-3 days for processing. Creating a new record will
-                      reset the workflow.
+                      upto 2-3 days for processing. Are you sure you want to proceed?
                     </Alert>
                   ) : null}
                 </Stack>

--- a/src/features/Rent/components/Widgets/QuickActions.jsx
+++ b/src/features/Rent/components/Widgets/QuickActions.jsx
@@ -274,7 +274,8 @@ export default function QuickActions({ property }) {
                   {hasRecentPaymentAttemptBeenMade ? (
                     <Alert variant="filled" severity="error">
                       A rent payment was recently attempted. Businesses may take
-                      upto 2-3 days for processing. Are you sure you want to proceed?
+                      upto 2-3 days for processing. Are you sure you want to
+                      proceed?
                     </Alert>
                   ) : null}
                 </Stack>


### PR DESCRIPTION
- Some rental payments take longer than expected. These payments might confuse users and they may tend to pay twice for the same rent. Adding a banner to confirm that users are sure that they know what they are doing.