### PR TITLE
Updated Rent Records

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -18,15 +18,21 @@ import {
 import { EsignAppRoutes } from "features/Esign/Routes";
 import { InvoiceAppRoutes } from "features/Invoice/Routes";
 import SplashPage from "features/Layout/SplashPage";
-import Contact from "features/Layout/components/Footer/Contact";
-import HelpCenter from "features/Layout/components/Footer/HelpCenter";
-import PrivacyPolicy from "features/Layout/components/Footer/PrivacyPolicy";
-import TermsOfService from "features/Layout/components/Footer/TermsOfService";
 import { RentalAppRoutes } from "features/Rent/Routes";
 import SubAppRouter from "src/SubRouter";
 
 const ReleaseNotes = lazy(
   () => import("features/Layout/components/HelpAndSupport/ReleaseNotes"),
+);
+const Contact = lazy(() => import("features/Layout/components/Footer/Contact"));
+const HelpCenter = lazy(
+  () => import("features/Layout/components/Footer/HelpCenter"),
+);
+const PrivacyPolicy = lazy(
+  () => import("features/Layout/components/Footer/PrivacyPolicy"),
+);
+const TermsOfService = lazy(
+  () => import("features/Layout/components/Footer/TermsOfService"),
 );
 
 // MainAppRoutes ...

--- a/src/features/Layout/components/Footer/PrivacyPolicy.jsx
+++ b/src/features/Layout/components/Footer/PrivacyPolicy.jsx
@@ -33,20 +33,20 @@ export default function PrivacyPolicy() {
       </Typography>
 
       <Typography>
-        Earmuffjam LLC, (hereinafter, $&quot;Homehive Solutions,$&quot;
-        $&quot;we,$&quot; $&quot;our,$&quot; or $&quot;us$&quot;) provides
-        property management software, invoice creation, and electronic signature
-        services (collectively, the $&quot;Services$&quot;) to landlords,
-        property managers, tenants, and other users (collectively,
-        $&quot;you$&quot; or $&quot;your$&quot;) through its website,
-        https://homehivesolutions.com/ (the $&quot;Site$&quot;).
+        Earmuffjam LLC, (hereinafter, &quot;Homehive Solutions,&quot;
+        &quot;we,&quot; &quot;our,&quot; or &quot;us&quot;) provides property
+        management software, invoice creation, and electronic signature services
+        (collectively, the &quot;Services&quot;) to landlords, property
+        managers, tenants, and other users (collectively, &quot;you&quot; or
+        &quot;your&quot;) through its website, https://homehivesolutions.com/
+        (the &quot;Site&quot;).
       </Typography>
 
       <Typography>
-        This privacy policy ($&quot;Privacy Policy$&quot;) explains the types of
+        This privacy policy (&quot;Privacy Policy&quot;) explains the types of
         information relating to an identified or identifiable natural person, or
-        as otherwise defined under applicable Privacy Laws, ($&quot;Personal
-        Data$&quot;) that we may collect from you when you use the Services or
+        as otherwise defined under applicable Privacy Laws, (&quot;Personal
+        Data&quot;) that we may collect from you when you use the Services or
         interact with the Site or any affiliated third-party website that may
         contain a link to this Privacy Policy. Unless explicitly stated
         otherwise, any current, updated and new software and products, including

--- a/src/features/Rent/common/PropertyHeader.jsx
+++ b/src/features/Rent/common/PropertyHeader.jsx
@@ -1,13 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 
-import { Home, HomeWorkOutlined } from "@mui/icons-material";
+import { CommentRounded, Home, HomeWorkOutlined } from "@mui/icons-material";
 import { Box, Chip, Stack, Tooltip, Typography } from "@mui/material";
+import AIconButton from "common/AIconButton";
 
 export default function PropertyHeader({
   property,
   isRentee = false,
   isPrimaryRenter = false,
 }) {
+  const [showNote, setShowNote] = useState(false);
+
   return (
     <Stack spacing={1}>
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
@@ -27,7 +30,11 @@ export default function PropertyHeader({
             {property?.sqFt && (
               <Box>
                 <Tooltip title={`${property?.sqFt} sq.ft `}>
-                  <Chip size="small" label={`${property?.sqFt} sq.ft`} />
+                  <Chip
+                    size="small"
+                    label={`${property?.sqFt} sq.ft`}
+                    color="primary"
+                  />
                 </Tooltip>
               </Box>
             )}
@@ -39,6 +46,30 @@ export default function PropertyHeader({
               {property?.address}, {property?.city}, {property?.state}&nbsp;
               {property?.zipcode}
             </Typography>
+          </Stack>
+          <Stack direction="row" alignItems="center" spacing={1} padding={1}>
+            <Tooltip title={showNote ? "Hide notes" : "Show notes"}>
+              <AIconButton
+                size="small"
+                onClick={() => setShowNote(!showNote)}
+                label={<CommentRounded fontSize="small" color="info" />}
+              />
+            </Tooltip>
+            {showNote && (
+              <Typography
+                variant="subtitle2"
+                color="text.secondary"
+                sx={{
+                  border: "1px solid",
+                  borderColor: "primary.main",
+                  paddingX: 2,
+                  paddingY: 0.1,
+                  borderRadius: 1,
+                }}
+              >
+                {property?.note}
+              </Typography>
+            )}
           </Stack>
         </Stack>
       </Box>

--- a/src/features/Rent/common/PropertyHeader.test.js
+++ b/src/features/Rent/common/PropertyHeader.test.js
@@ -3,6 +3,11 @@ import React from "react";
 import PropertyHeader from "./PropertyHeader";
 import { render, screen } from "@testing-library/react";
 
+jest.mock("common/AIconButton", () => ({
+  __esModule: true,
+  default: (props) => <button {...props} />,
+}));
+
 describe("PropertyHeader Jest tests", () => {
   describe("PropertyHeader snapshot tests", () => {
     it("renders correctly and matches snapshot", () => {

--- a/src/features/Rent/common/__snapshots__/PropertyHeader.test.js.snap
+++ b/src/features/Rent/common/__snapshots__/PropertyHeader.test.js.snap
@@ -36,6 +36,16 @@ exports[`PropertyHeader Jest tests PropertyHeader snapshot tests renders correct
             123 Main St, Austin, TX 78701
           </h6>
         </div>
+        <div
+          class="MuiStack-root css-9xnnam-MuiStack-root"
+        >
+          <button
+            aria-label="Show notes"
+            class=""
+            data-mui-internal-clone-element="true"
+            label="[object Object]"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/features/Rent/components/AddRentRecords/AddRentRecords.jsx
+++ b/src/features/Rent/components/AddRentRecords/AddRentRecords.jsx
@@ -153,7 +153,6 @@ export default function AddRentRecords({
             id="ownerFirstName"
             placeholder="First Name of your property owner"
             errorMsg={errors.ownerFirstName?.message}
-            isDisabled
             inputProps={{
               ...register("ownerFirstName", {
                 required: "Owner First Name is required",
@@ -165,7 +164,6 @@ export default function AddRentRecords({
             id="ownerLastName"
             placeholder="Last Name of your property owner"
             errorMsg={errors.ownerLastName?.message}
-            isDisabled
             inputProps={{
               ...register("ownerLastName", {
                 required: "Owner Last Name is required",

--- a/src/features/Rent/components/AddRentRecords/__snapshots__/AddRentRecords.test.js.snap
+++ b/src/features/Rent/components/AddRentRecords/__snapshots__/AddRentRecords.test.js.snap
@@ -31,7 +31,7 @@ exports[`AddRentRecords Component Tests AddRentRecords Snapshot Tests matches Ad
             class="MuiStack-root css-niqf4j-MuiStack-root"
           >
             <span
-              class="MuiBox-root css-1mmsew2"
+              class="MuiBox-root css-1ta4aep"
               variant="body2"
             >
               Owner First Name *
@@ -41,12 +41,11 @@ exports[`AddRentRecords Component Tests AddRentRecords Snapshot Tests matches Ad
             class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
-                disabled=""
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
                 id="ownerFirstName"
                 name="ownerFirstName"
                 placeholder="First Name of your property owner"
@@ -78,7 +77,7 @@ exports[`AddRentRecords Component Tests AddRentRecords Snapshot Tests matches Ad
             class="MuiStack-root css-niqf4j-MuiStack-root"
           >
             <span
-              class="MuiBox-root css-1mmsew2"
+              class="MuiBox-root css-1ta4aep"
               variant="body2"
             >
               Owner Last Name *
@@ -88,12 +87,11 @@ exports[`AddRentRecords Component Tests AddRentRecords Snapshot Tests matches Ad
             class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
-                disabled=""
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
                 id="ownerLastName"
                 name="ownerLastName"
                 placeholder="Last Name of your property owner"


### PR DESCRIPTION
- Removed isDisabled flag for property owner details in form fields of AddRent Records. This allows property owners to write their own name when filling out rent records since they might not want to save it from the profile details page all the time.

- Also add lazy routes for Help Center, Contact us and Privacy Policies

Closes #333