### PR TITLE
Changed signature fields to date

### DIFF
--- a/src/features/Esign/components/Esign/PdfEditor.jsx
+++ b/src/features/Esign/components/Esign/PdfEditor.jsx
@@ -373,7 +373,7 @@ const PdfEditor = () => {
     return signatureBoxes?.map((signatureBox, index) => ({
       document_index: 0,
       api_id: `sig_${index}`,
-      type: signatureBox.fieldType === "date" ? "text" : "signature",
+      type: signatureBox.fieldType === "date" ? "date" : "signature",
       signer:
         signatureBox?.signerId === "creator"
           ? 0


### PR DESCRIPTION
The purpose of this PR is to change the signature fields from text to date. This stops the user from inputting anything but date in the date signed column.