### PR TITLE
Added tests for next payment due date

### DIFF
--- a/src/features/Rent/components/AssociateTenantPopup/AssociateTenantPopup.test.js
+++ b/src/features/Rent/components/AssociateTenantPopup/AssociateTenantPopup.test.js
@@ -73,6 +73,15 @@ jest.mock("common/AButton", () => ({
 }));
 
 describe("AssociateTenantPopup test", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-12T12:00:00.000Z"));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe("AssociateTenantPopup", () => {
     const props = {
       closeDialog: jest.fn(),

--- a/src/features/Rent/constants.jsx
+++ b/src/features/Rent/constants.jsx
@@ -113,3 +113,18 @@ export const DefaultMaintenanceCategoryTypes = [
     label: "General Repair",
   },
 ];
+
+// STARTER_PLAN_PRODUCT_NAME
+export const STARTER_PLAN_PRODUCT_NAME = "Monthly Starter Plan";
+// PROFESSIONAL_PLAN_PRODUCT_NAME
+export const PROFESSIONAL_PLAN_PRODUCT_NAME = "Monthly Professional Plan";
+// ENTERPRISE_PLAN_PRODUCT_NAME
+export const ENTERPRISE_PLAN_PRODUCT_NAME = "Monthly Enterprise Plan";
+
+// DefaultRentXPropertiesLimit ...
+// defines the max amount of authorized properties for each plan
+export const DefaultRentXPropertiesLimit = {
+  [STARTER_PLAN_PRODUCT_NAME]: 2,
+  [PROFESSIONAL_PLAN_PRODUCT_NAME]: 10,
+  [ENTERPRISE_PLAN_PRODUCT_NAME]: 20,
+};

--- a/src/features/Rent/hooks/useGetSelectedPropertyDetails.js
+++ b/src/features/Rent/hooks/useGetSelectedPropertyDetails.js
@@ -59,8 +59,7 @@ export const useSelectedPropertyDetails = (
       ].includes(currentMonthRent?.status);
 
     if (!isCurrentMonthPaid) {
-      // if current month is not paid, show the next month after
-      // last payment was made
+      // if current month is not paid, show the next month after last payment was made
       const rentPaidMonth = currentMonthRent?.rentMonth;
       nextRentalPaymentDueDate = dayjs(
         `${rentPaidMonth} ${today.year()}`,

--- a/src/features/Rent/hooks/useGetSelectedPropertyDetails.js
+++ b/src/features/Rent/hooks/useGetSelectedPropertyDetails.js
@@ -51,7 +51,7 @@ export const useSelectedPropertyDetails = (
 
   if (currentMonthRent) {
     const isCurrentMonthPaid =
-      currentMonthRent?.rentMonth === today.month() &&
+      currentMonthRent?.rentMonth === today.format("MMMM") &&
       [
         ManualRentStatusEnumValue,
         CompleteRentStatusEnumValue,
@@ -59,10 +59,15 @@ export const useSelectedPropertyDetails = (
       ].includes(currentMonthRent?.status);
 
     if (!isCurrentMonthPaid) {
-      nextRentalPaymentDueDate = nextDueDate.subtract(
-        monthsSinceStart + 1,
-        "month",
-      );
+      // if current month is not paid, show the next month after
+      // last payment was made
+      const rentPaidMonth = currentMonthRent?.rentMonth;
+      nextRentalPaymentDueDate = dayjs(
+        `${rentPaidMonth} ${today.year()}`,
+        "MMMM YYYY",
+      )
+        .startOf("month")
+        .add(1, "month");
     }
   }
 

--- a/src/features/Rent/hooks/useGetSelectedPropertyDetails.test.js
+++ b/src/features/Rent/hooks/useGetSelectedPropertyDetails.test.js
@@ -1,7 +1,7 @@
 import { useSelectedPropertyDetails } from "features/Rent/hooks/useGetSelectedPropertyDetails";
 import { ManualRentStatusEnumValue } from "features/Rent/utils";
 
-describe("useGetSelectedPropertyDetailsHook tests", () => {
+describe("for useGetSelectedPropertyDetailsHook tests", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date("2026-04-15T12:00:00Z"));

--- a/src/features/Rent/hooks/useGetSelectedPropertyDetails.test.js
+++ b/src/features/Rent/hooks/useGetSelectedPropertyDetails.test.js
@@ -1,0 +1,146 @@
+import { useSelectedPropertyDetails } from "features/Rent/hooks/useGetSelectedPropertyDetails";
+import { ManualRentStatusEnumValue } from "features/Rent/utils";
+
+describe("useGetSelectedPropertyDetailsHook tests", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("for non SoR properties", () => {
+    const mockProperty = {
+      id: 1,
+      title: "Test Property",
+      rent: 2000,
+      additionalRent: 500,
+    };
+
+    const mockPrimaryTenant = {
+      id: 1,
+      startDate: "2026-01-01",
+      firstName: "john",
+      lastName: "doe",
+      isPrimary: true,
+      isSoR: false,
+    };
+
+    const mockSecondaryTenant = {
+      id: 1,
+      startDate: "2026-02-01",
+      firstName: "Jane",
+      lastName: "Smith",
+      isPrimary: true,
+      isSoR: false,
+    };
+
+    const mockCurrentMonthRent = {
+      rentMonth: "April",
+      status: ManualRentStatusEnumValue,
+    };
+
+    it("should return correct values when current month is paid", () => {
+      const result = useSelectedPropertyDetails(
+        mockProperty,
+        [mockPrimaryTenant, mockSecondaryTenant],
+        mockCurrentMonthRent,
+      );
+
+      expect(result.totalRent).toBe(2500);
+      expect(result.nextPaymentDueDate).toBe("May 01");
+      expect(result.isSelectedPropertySoR).toBe(false); // default SoR is false
+    });
+
+    it("should return correct values when no rental payment data is detected", () => {
+      const result = useSelectedPropertyDetails(
+        mockProperty,
+        [mockPrimaryTenant, mockSecondaryTenant],
+        null,
+      );
+
+      expect(result.totalRent).toBe(2500);
+      expect(result.nextPaymentDueDate).toBe("May 01");
+      expect(result.isSelectedPropertySoR).toBe(false); // default SoR is false
+    });
+  });
+
+  describe("for unpaid rental payments", () => {
+    const mockProperty = {
+      id: 1,
+      title: "Test Property",
+      rent: 2000,
+      additionalRent: 500,
+    };
+
+    const mockPrimaryTenant = {
+      id: 1,
+      startDate: "2026-01-01",
+      firstName: "john",
+      lastName: "doe",
+      isPrimary: true,
+      isSoR: false,
+    };
+
+    const mockSecondaryTenant = {
+      id: 1,
+      startDate: "2026-02-01",
+      firstName: "Jane",
+      lastName: "Smith",
+      isPrimary: true,
+      isSoR: false,
+    };
+
+    const mockPreviousMonthRent = {
+      rentMonth: "March",
+      status: ManualRentStatusEnumValue,
+    };
+
+    it("should return correct values when rental payment intent is not complete", () => {
+      const result = useSelectedPropertyDetails(
+        mockProperty,
+        [mockPrimaryTenant, mockSecondaryTenant],
+        mockPreviousMonthRent,
+      );
+
+      expect(result.totalRent).toBe(2500);
+      expect(result.nextPaymentDueDate).toBe("Apr 01"); // next month after last payment was made
+      expect(result.isSelectedPropertySoR).toBe(false); // default SoR is false
+    });
+  });
+
+  describe("for missing properties or tenants not provisioned yet", () => {
+    const mockProperty = {
+      id: 1,
+      title: "Test Property",
+    };
+
+    const mockPrimaryTenant = {
+      id: 1,
+      startDate: "2026-05-01",
+      firstName: "john",
+      lastName: "doe",
+      isPrimary: true,
+      isSoR: false,
+    };
+
+    const mockPreviousMonthRent = {
+      rentMonth: "March",
+      status: ManualRentStatusEnumValue,
+    };
+
+    it("should return correct values when rental payment intent is not complete", () => {
+      const result = useSelectedPropertyDetails(
+        mockProperty,
+        [mockPrimaryTenant],
+        mockPreviousMonthRent,
+      );
+
+      expect(result.totalRent).toBe(0);
+      expect(result.nextPaymentDueDate).toBe("May 01"); // day of provision
+      expect(result.isSelectedPropertySoR).toBe(false); // default SoR is false
+    });
+  });
+});

--- a/src/features/Rent/hooks/useVerifySubscriptionForProperties.js
+++ b/src/features/Rent/hooks/useVerifySubscriptionForProperties.js
@@ -1,14 +1,7 @@
-// AllowedPropertiesSubscription ...
 import dayjs from "dayjs";
 
 import { Role } from "features/Auth/AuthHelper";
-
-// defines the allowed properties for each of the associated plan
-const AllowedPropertiesSubscription = {
-  prod_ULLSTCXPNbCB1r: 2, // starter plan
-  prod_ULLVYsSQ3f2VnB: 10, // professional plan
-  prod_ULLWJBO7h4uOoG: 10000, // enterprise plan
-};
+import { DefaultRentXPropertiesLimit } from "features/Rent/constants";
 
 // useVerifySubscriptionForProperties ...
 // defines a function that verifies the subscription details for the logged in user.
@@ -32,7 +25,7 @@ export const useVerifySubscriptionForProperties = (
   if (userRole === Role.Owner) {
     const selectedSubscription = subscriptionOptions?.find(
       (option) =>
-        option.productId === latestSubscription?.subscriptionProductId,
+        option.productName === latestSubscription?.subscriptionProductName,
     );
 
     // check if the user is within the trial period
@@ -46,7 +39,7 @@ export const useVerifySubscriptionForProperties = (
     }
 
     const allowedPropertiesLimit =
-      AllowedPropertiesSubscription[selectedSubscription?.productId] || 0;
+      DefaultRentXPropertiesLimit[selectedSubscription?.productName] || 0;
 
     return {
       canAddProperty: activePropertiesCount < allowedPropertiesLimit,

--- a/src/features/Rent/hooks/useVerifySubscriptionForProperties.test.js
+++ b/src/features/Rent/hooks/useVerifySubscriptionForProperties.test.js
@@ -1,0 +1,179 @@
+import dayjs from "dayjs";
+
+import { Role } from "features/Auth/AuthHelper";
+import {
+  PROFESSIONAL_PLAN_PRODUCT_NAME,
+  STARTER_PLAN_PRODUCT_NAME,
+} from "features/Rent/constants";
+import { useVerifySubscriptionForProperties } from "features/Rent/hooks/useVerifySubscriptionForProperties";
+
+const mockUser = {
+  id: 1,
+  email: "testUser@gmail.com",
+};
+
+const mockUserData = {
+  firstName: "John",
+  lastName: "Smith",
+  createdOn: "2026-04-25T02:12:20.318Z",
+};
+
+const mockLatestSubscription = {
+  id: "stripeCustomerIdTest",
+  subscriptionProductName: "Monthly Professional Plan",
+  subscriptionStatus: "paid",
+  stripeSubscriptionId: "sub_1Thh3WHDqURY09L2D3C3RVGy",
+  createdOn: "2026-04-17T02:12:20.318Z",
+  stripeCustomerEmail: "testUser@gmail.com",
+  stripeCustomerId: "stripeCustomerIdTest",
+  stripeInvoiceId: "in_1Thh3UHDqURY09L2AFv2QzXf",
+  updatedOn: "2026-04-17T02:12:37.013Z",
+  stripeEventType: "checkout.session.async_payment_succeeded",
+  subscriptionAmount: 5,
+  isFirstSubscriptionForCustomer: false,
+};
+
+const mockSubscriptionOptions = [
+  {
+    productId: 1,
+    productName: PROFESSIONAL_PLAN_PRODUCT_NAME,
+    description:
+      "Best for growing portfolios with up to 10 properties. Billed Monthly",
+    priceId: "testPriceIdForMonthlyProfessionalPlan",
+    amount: 500,
+    currency: "usd",
+    interval: "month",
+  },
+  {
+    productId: 2,
+    productName: STARTER_PLAN_PRODUCT_NAME,
+    description:
+      "Perfect for small landlords managing up to 2 properties. Billed monthly.",
+    priceId: "testPriceIdForMonthlyStarterPlan",
+    amount: 200,
+    currency: "usd",
+    interval: "month",
+  },
+];
+
+describe("for useVerifySubscriptionForProperties tests", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("for general users", () => {
+    it("should not be able to add property", () => {
+      // general users do not have correct perms
+      const mockGeneralUser = { ...mockUser, role: Role.User };
+      const result = useVerifySubscriptionForProperties(
+        mockGeneralUser,
+        mockUserData?.createdOn,
+        mockLatestSubscription,
+        mockSubscriptionOptions,
+      );
+
+      expect(result.displayAlert).toBe(false);
+      expect(result.canAddProperty).toBe(false); // general users
+    });
+  });
+
+  describe("for tenants", () => {
+    it("should not be able to add property", () => {
+      const mockTenantUser = { ...mockUser, role: Role.Tenant };
+
+      const result = useVerifySubscriptionForProperties(
+        mockTenantUser,
+        mockUserData?.createdOn,
+        mockLatestSubscription,
+        mockSubscriptionOptions,
+      );
+
+      expect(result.displayAlert).toBe(false);
+      expect(result.canAddProperty).toBe(false);
+    });
+  });
+
+  describe("for admins", () => {
+    it("should be able to add property for professional plan", () => {
+      const mockAdminUser = { ...mockUser, role: Role.Admin };
+      const result = useVerifySubscriptionForProperties(
+        mockAdminUser,
+        mockUserData?.createdOn,
+        mockLatestSubscription,
+        mockSubscriptionOptions,
+      );
+      expect(result.displayAlert).toBe(false);
+      expect(result.canAddProperty).toBe(true);
+    });
+
+    it("should be able to add property for any plan despite limit for admins", () => {
+      const mockAdminUser = { ...mockUser, role: Role.Admin };
+      const mockUpdatedLatestSubscription = {
+        ...mockLatestSubscription,
+        subscriptionProductName: STARTER_PLAN_PRODUCT_NAME,
+      };
+
+      // switched plan to starter to validate admin role
+      const result = useVerifySubscriptionForProperties(
+        mockAdminUser,
+        mockUserData?.createdOn,
+        mockUpdatedLatestSubscription,
+        mockSubscriptionOptions,
+      );
+      expect(result.displayAlert).toBe(false);
+      expect(result.canAddProperty).toBe(true);
+    });
+  });
+
+  describe("for property owners", () => {
+    it("should be able to add property for professional plan", () => {
+      const mockPropertyOwnerUser = { ...mockUser, role: Role.Owner };
+      const result = useVerifySubscriptionForProperties(
+        mockPropertyOwnerUser,
+        mockUserData?.createdOn,
+        mockLatestSubscription,
+        mockSubscriptionOptions,
+      );
+      expect(result.displayAlert).toBe(false);
+      expect(result.canAddProperty).toBe(true);
+    });
+    it("should not be able to add property for starter plan", () => {
+      const mockPropertyOwnerUser = { ...mockUser, role: Role.Owner };
+      const mockUpdatedLatestSubscription = {
+        ...mockLatestSubscription,
+        subscriptionProductName: STARTER_PLAN_PRODUCT_NAME,
+      };
+      const result = useVerifySubscriptionForProperties(
+        mockPropertyOwnerUser,
+        mockUserData?.createdOn,
+        mockUpdatedLatestSubscription,
+        mockSubscriptionOptions,
+        2,
+      );
+      expect(result.displayAlert).toBe(false);
+      expect(result.canAddProperty).toBe(false);
+    });
+    it("should be able to display alert for new property owners", () => {
+      const mockPropertyOwnerUser = { ...mockUser, role: Role.Owner };
+      const mockUpdatedLatestSubscription = {
+        ...mockLatestSubscription,
+        subscriptionProductName: STARTER_PLAN_PRODUCT_NAME,
+        isFirstSubscriptionForCustomer: true,
+      };
+      const result = useVerifySubscriptionForProperties(
+        mockPropertyOwnerUser,
+        mockUserData?.createdOn,
+        mockUpdatedLatestSubscription,
+        mockSubscriptionOptions,
+        0,
+      );
+      expect(result.displayAlert).toBe(true);
+      expect(result.canAddProperty).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
- Resolved issue where the date was not correct, when the current month was paid, since we were calculating the date wrong. Also added test for this feature

- Updated nextRentalPaymentDate when current month is paid, so that the calculation would be from the last time the rent was paid, not the start of the lease term. The bug was that the calculation was hapenning from the start of the lease term. Also added tests for this.