### PR TITLE
Added cleanup to AddMaintenanceDetails test

### DIFF
--- a/src/features/Rent/components/Maintenance/AddMaintenanceDetails.jsx
+++ b/src/features/Rent/components/Maintenance/AddMaintenanceDetails.jsx
@@ -44,7 +44,7 @@ import {
 const DefaultValuesCreateMaintenanceItem = {
   tenantFirstName: "",
   tenantLastName: "",
-  tenantEmailAddress: "",
+  tenantEmail: "",
   maintenanceCategory: "",
   description: "",
   status: "",
@@ -101,7 +101,6 @@ const AddMaintenanceDetails = ({ property, setShowSnackbar, closeDialog }) => {
     createMaintenanceRecord({
       ...data,
       id: uuidv4(),
-      tenantEmail: primaryTenant?.email,
       propertyId: property?.id,
       propertyOwnerId: property?.createdBy,
       tenantId: primaryTenant?.id,
@@ -120,6 +119,8 @@ const AddMaintenanceDetails = ({ property, setShowSnackbar, closeDialog }) => {
 
       const maintenanceId = maintenanceRecordOriginalArgs?.id;
       const propertyId = maintenanceRecordOriginalArgs?.propertyId;
+      // if no tenant is found, use whoever the creator put under tenant email
+      const emailAddress = maintenanceRecordOriginalArgs?.tenantEmail;
 
       const populatedImages = selectedImages.map((image) => ({
         file: image.file,
@@ -134,7 +135,7 @@ const AddMaintenanceDetails = ({ property, setShowSnackbar, closeDialog }) => {
       );
 
       formatAndSendNotification({
-        to: primaryTenant?.email,
+        to: emailAddress,
         subject: `${AddMaintenanceRecordEnumValue} - ${property.name}`,
         body: emailMsgWithDisclaimer,
         ccEmailIds: [user?.email],
@@ -145,7 +146,7 @@ const AddMaintenanceDetails = ({ property, setShowSnackbar, closeDialog }) => {
 
   useEffect(() => {
     if (primaryTenant) {
-      setValue("tenantEmailAddress", primaryTenant?.email);
+      setValue("tenantEmail", primaryTenant?.email);
     }
   }, [primaryTenant?.id]);
 
@@ -189,12 +190,14 @@ const AddMaintenanceDetails = ({ property, setShowSnackbar, closeDialog }) => {
           />
         </Stack>
         <TextFieldWithLabel
+          // disabled if primary tenant is found
+          isDisabled={primaryTenant?.email}
           label="Email Address *"
-          id="tenantEmailAddress"
+          id="tenantEmail"
           placeholder="Email address of the primary tenant"
-          errorMsg={errors.tenantEmailAddress?.message}
+          errorMsg={errors.tenantEmail?.message}
           inputProps={{
-            ...register("tenantEmailAddress", {
+            ...register("tenantEmail", {
               required: "Email address is required",
             }),
           }}

--- a/src/features/Rent/components/Maintenance/AddMaintenanceDetails.test.js
+++ b/src/features/Rent/components/Maintenance/AddMaintenanceDetails.test.js
@@ -1,0 +1,169 @@
+import React from "react";
+
+import AddMaintenanceDetails from "./AddMaintenanceDetails";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("common/utils", () => ({
+  fetchLoggedInUser: jest.fn(() => ({
+    uid: "user-1",
+    email: "owner@test.com",
+  })),
+}));
+
+jest.mock("common/AIconButton", () => ({
+  __esModule: true,
+  default: (props) => <button {...props} />,
+}));
+
+jest.mock("common/AButton", () => ({
+  __esModule: true,
+  default: ({ label, onClick, disabled }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {label}
+    </button>
+  ),
+}));
+
+jest.mock("features/Api/externalIntegrationsApi", () => ({
+  useSendEmailMutation: () => [jest.fn()],
+}));
+
+jest.mock("features/Api/firebaseStorageApi", () => ({
+  useUploadMultipleImagesMutation: () => [jest.fn()],
+}));
+
+jest.mock("features/Api/firebaseUserApi", () => ({
+  useGetUserByEmailAddressQuery: () => ({
+    data: { firstName: "John", lastName: "Doe" },
+    isLoading: false,
+  }),
+}));
+
+const mockCreateMaintenanceRecord = jest.fn();
+jest.mock("features/Api/maintenanceApi", () => ({
+  useCreateMaintenanceRecordMutation: () => [
+    mockCreateMaintenanceRecord,
+    { originalArgs: {}, isLoading: false, isSuccess: false },
+  ],
+}));
+
+jest.mock("features/Api/tenantsApi", () => ({
+  useGetTenantByPropertyIdQuery: () => ({
+    data: [{ id: "tenant-1", email: "tenant@test.com", isPrimary: true }],
+  }),
+}));
+
+jest.mock(
+  "features/Rent/components/Image/MultipleImagePicker",
+  () => (props) => <div data-testid="multiple-image-picker" />,
+);
+
+jest.mock("features/Rent/utils", () => ({
+  AddMaintenanceRecordEnumValue: "Maintenance request added",
+  appendDisclaimer: jest.fn((msg) => msg),
+  emailMessageBuilder: jest.fn(() => "email body"),
+  formatAndSendNotification: jest.fn(),
+  isFeatureEnabled: jest.fn(() => true),
+}));
+
+const property = {
+  id: "prop-1",
+  name: "Sunset Villa",
+  createdBy: "owner-1",
+};
+const setShowSnackbar = jest.fn();
+const closeDialog = jest.fn();
+
+describe("AddMaintenanceDetails tests", () => {
+  describe("AddMaintenanceDetails snapshot tests", () => {
+    const defaultProps = {
+      property,
+      setShowSnackbar,
+      closeDialog,
+    };
+    it("matches snapshot", () => {
+      const { container } = render(<AddMaintenanceDetails {...defaultProps} />);
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe("AddMaintenanceDetails component tests", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("renders the tenant and maintenance request fields", () => {
+      render(
+        <AddMaintenanceDetails
+          property={property}
+          setShowSnackbar={setShowSnackbar}
+          closeDialog={closeDialog}
+        />,
+      );
+
+      expect(screen.getByText(/Tenant Information/i)).toBeInTheDocument();
+      expect(screen.getByText(/^Maintenance Request$/i)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("First Name")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Last Name")).toBeInTheDocument();
+      expect(screen.getByTestId("multiple-image-picker")).toBeInTheDocument();
+    });
+
+    it("disables the submit button until required fields are filled", async () => {
+      render(
+        <AddMaintenanceDetails
+          property={property}
+          setShowSnackbar={setShowSnackbar}
+          closeDialog={closeDialog}
+        />,
+      );
+
+      const submitButton = screen.getByText(/Create maintenance request/i);
+      expect(submitButton).toBeDisabled();
+
+      fireEvent.input(screen.getByPlaceholderText("First Name"), {
+        target: { value: "Jane" },
+      });
+      fireEvent.input(screen.getByPlaceholderText("Last Name"), {
+        target: { value: "Smith" },
+      });
+
+      await waitFor(() => {
+        expect(submitButton).not.toBeDisabled();
+      });
+    });
+
+    it("calls createMaintenanceRecord with expected payload on submit", async () => {
+      render(
+        <AddMaintenanceDetails
+          property={property}
+          setShowSnackbar={setShowSnackbar}
+          closeDialog={closeDialog}
+        />,
+      );
+
+      fireEvent.input(screen.getByPlaceholderText("First Name"), {
+        target: { value: "Jane" },
+      });
+      fireEvent.input(screen.getByPlaceholderText("Last Name"), {
+        target: { value: "Smith" },
+      });
+
+      const submitButton = screen.getByText(/Create maintenance request/i);
+      await waitFor(() => expect(submitButton).not.toBeDisabled());
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockCreateMaintenanceRecord).toHaveBeenCalledWith(
+          expect.objectContaining({
+            propertyId: "prop-1",
+            propertyOwnerId: "owner-1",
+            tenantId: "tenant-1",
+          }),
+        );
+      });
+    });
+  });
+});

--- a/src/features/Rent/components/Maintenance/ViewMaintenanceRecord.test.js
+++ b/src/features/Rent/components/Maintenance/ViewMaintenanceRecord.test.js
@@ -35,8 +35,8 @@ jest.mock("material-react-table", () => ({
 
 jest.mock("common/CustomSnackbar", () => () => <div>CustomSnackbar</div>);
 
-describe("View maintenance record tests", () => {
-  describe("ViewMaintenanceRecord", () => {
+describe("ViewMaintenanceRecord", () => {
+  describe("ViewMaintenanceRecord snapshot tests", () => {
     const defaultProps = {
       propertyName: "Test Property",
       primaryTenantEmail: "tenant@test.com",
@@ -58,8 +58,7 @@ describe("View maintenance record tests", () => {
       expect(container.firstChild).toMatchSnapshot();
     });
   });
-
-  describe("ViewMaintenanceRecord behavior", () => {
+  describe("ViewMaintenanceRecord component tests", () => {
     const defaultProps = {
       propertyName: "Test Property",
       primaryTenantEmail: "tenant@test.com",

--- a/src/features/Rent/components/Maintenance/__snapshots__/AddMaintenanceDetails.test.js.snap
+++ b/src/features/Rent/components/Maintenance/__snapshots__/AddMaintenanceDetails.test.js.snap
@@ -1,0 +1,329 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddMaintenanceDetails tests AddMaintenanceDetails snapshot tests matches snapshot 1`] = `
+<form>
+  <div
+    class="MuiStack-root css-jfdv4h-MuiStack-root"
+  >
+    <div
+      aria-orientation="horizontal"
+      class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren css-1oljykh-MuiDivider-root"
+      role="separator"
+    >
+      <span
+        class="MuiDivider-wrapper css-1134oje-MuiDivider-wrapper"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-caption css-1jkzbat-MuiTypography-root"
+        >
+          Tenant Information
+        </span>
+      </span>
+    </div>
+    <div
+      class="MuiStack-root css-1wi0p3l-MuiStack-root"
+    >
+      <div
+        class="MuiStack-root css-9j5txs-MuiStack-root"
+      >
+        <div
+          class="MuiStack-root css-niqf4j-MuiStack-root"
+        >
+          <span
+            class="MuiBox-root css-1ta4aep"
+            variant="body2"
+          >
+            First Name *
+          </span>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="First Name *"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+              id="tenantFirstName"
+              name="tenantFirstName"
+              placeholder="First Name"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiStack-root css-9j5txs-MuiStack-root"
+      >
+        <div
+          class="MuiStack-root css-niqf4j-MuiStack-root"
+        >
+          <span
+            class="MuiBox-root css-1ta4aep"
+            variant="body2"
+          >
+            Tenant Last Name *
+          </span>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="Tenant Last Name *"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+              id="tenantLastName"
+              name="tenantLastName"
+              placeholder="Last Name"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiStack-root css-9j5txs-MuiStack-root"
+    >
+      <div
+        class="MuiStack-root css-niqf4j-MuiStack-root"
+      >
+        <span
+          class="MuiBox-root css-1mmsew2"
+          variant="body2"
+        >
+          Email Address *
+        </span>
+      </div>
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Email Address *"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+            disabled=""
+            id="tenantEmail"
+            name="tenantEmail"
+            placeholder="Email address of the primary tenant"
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1nf2c5d-MuiNotchedOutlined-root"
+            >
+              <span
+                aria-hidden="true"
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-orientation="horizontal"
+      class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren css-1oljykh-MuiDivider-root"
+      role="separator"
+    >
+      <span
+        class="MuiDivider-wrapper css-1134oje-MuiDivider-wrapper"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-caption css-1jkzbat-MuiTypography-root"
+        >
+          Maintenance Request
+        </span>
+      </span>
+    </div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root css-12p7f1s-MuiFormControl-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1kfabtt-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          id="maintenance-category-label"
+        >
+          Maintenance type
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="maintenance-category-label maintenanceCategory"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-trm6af-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            id="maintenanceCategory"
+            role="combobox"
+            tabindex="0"
+          >
+            <span
+              aria-hidden="true"
+              class="notranslate"
+            >
+              ​
+            </span>
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            name="maintenanceCategory"
+            tabindex="-1"
+            value=""
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Maintenance type
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+        <p
+          class="MuiFormHelperText-root MuiFormHelperText-sizeSmall MuiFormHelperText-contained css-2s8ubb-MuiFormHelperText-root"
+        />
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-ieri5n"
+    >
+      <div
+        class="MuiStack-root css-9j5txs-MuiStack-root"
+      >
+        <div
+          class="MuiStack-root css-niqf4j-MuiStack-root"
+        >
+          <span
+            class="MuiBox-root css-1ta4aep"
+            variant="body2"
+          >
+            Description
+          </span>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-multiline css-szkf5z-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <textarea
+              aria-invalid="false"
+              aria-label="Description"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiInputBase-inputSizeSmall css-msbelq-MuiInputBase-input-MuiOutlinedInput-input"
+              id="description"
+              name="description"
+              placeholder="Enter description of the problem in less than 1000 characters"
+              rows="5"
+              style="height: 0px; overflow: hidden;"
+            />
+            <textarea
+              aria-hidden="true"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiInputBase-inputSizeSmall css-msbelq-MuiInputBase-input-MuiOutlinedInput-input"
+              readonly=""
+              style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
+              tabindex="-1"
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-kzfr2u"
+    >
+      <div
+        data-testid="multiple-image-picker"
+      />
+    </div>
+    <div
+      class="MuiBox-root css-56sg73"
+    >
+      <button
+        disabled=""
+      >
+        Create maintenance request
+      </button>
+    </div>
+  </div>
+</form>
+`;

--- a/src/features/Rent/components/Maintenance/__snapshots__/ViewMaintenanceRecord.test.js.snap
+++ b/src/features/Rent/components/Maintenance/__snapshots__/ViewMaintenanceRecord.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`View maintenance record tests ViewMaintenanceRecord matches snapshot 1`] = `
+exports[`ViewMaintenanceRecord ViewMaintenanceRecord snapshot tests matches snapshot 1`] = `
 <div
   class="MuiStack-root css-1sazv7p-MuiStack-root"
 >


### PR DESCRIPTION
- Added ability to use primaryEmail if the tenant exist, else the creator of the maintenance request can send the email to whoever they like. If the tenant creates the issue, there will always be a primaryEmail.

- Added tests and some other test cleanup for ViewMaintenanceRecords and for AddMaintenanceDetails